### PR TITLE
docs: DRA + Karpenter/Auto Mode 비호환 명시 및 GPU 노드 전략 업데이트

### DIFF
--- a/docs/agentic-ai-platform/model-serving/eks-gpu-node-strategy.md
+++ b/docs/agentic-ai-platform/model-serving/eks-gpu-node-strategy.md
@@ -826,9 +826,63 @@ Job Queueing:
 DRA(Dynamic Resource Allocation)는 K8s 1.34에서 GA로 승격되었으며, GPU 메모리 세밀 할당, MIG/MPS/Time-Slicing 선택, NVLink 토폴로지 인식 스케줄링 등 Device Plugin을 넘어서는 고급 GPU 관리를 제공합니다. **단, DRA는 Karpenter와 EKS Auto Mode에서 사용할 수 없습니다.**
 
 :::danger DRA + Karpenter/Auto Mode 비호환
-Karpenter는 Pod의 `spec.resourceClaims`를 감지하면 노드 프로비저닝을 skip합니다. EKS Auto Mode도 내부적으로 Karpenter를 사용하므로 동일한 제약이 적용됩니다. DRA 워크로드의 노드 관리는 **Managed Node Group**이 유일한 정식 지원 방법입니다.
+Karpenter는 Pod의 `spec.resourceClaims`를 감지하면 노드 프로비저닝을 skip합니다 ([PR #2384](https://github.com/kubernetes-sigs/karpenter/pull/2384)). EKS Auto Mode도 내부적으로 Karpenter를 사용하므로 동일한 제약이 적용됩니다. DRA 워크로드의 노드 관리는 **Managed Node Group**이 유일한 정식 지원 방법입니다.
+
+이것은 단순한 CRD 해석 문제가 아닙니다. Karpenter는 Pod 요구사항을 시뮬레이션해서 최적 인스턴스를 계산하는데, DRA의 ResourceSlice는 노드가 존재한 후에야 DRA Driver가 발행하므로 **노드 생성 전 시뮬레이션이 불가능**합니다(닭과 달걀 문제). 반면 Cluster Autoscaler는 "Pending Pod이 있으니 MNG를 스케일업해"라는 단순 판단만 하므로 DRA를 해석할 필요 없이 동작합니다.
 
 **참고**: [AWS EKS 공식 문서 — Manage hardware devices](https://docs.aws.amazon.com/eks/latest/userguide/device-management.html)
+:::
+
+#### Karpenter `IGNORE_DRA_REQUESTS` 워크어라운드 (PoC 용도)
+
+Karpenter의 `IGNORE_DRA_REQUESTS` 플래그를 활성화하면, DRA 요구사항을 무시하고 nodeSelector/라벨 기반으로 노드를 프로비저닝할 수 있습니다.
+
+```yaml
+# Karpenter에서 DRA 무시 활성화
+env:
+  - name: IGNORE_DRA_REQUESTS
+    value: "true"
+
+---
+# NodePool: GPU 라벨 매칭
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: gpu-dra-h100
+spec:
+  template:
+    metadata:
+      labels:
+        gpu-class: h100-80gb
+    spec:
+      requirements:
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values: ["p5.48xlarge"]
+
+---
+# DRA Pod: 라벨로 인스턴스 힌트 + ResourceClaim으로 GPU 할당
+apiVersion: v1
+kind: Pod
+spec:
+  nodeSelector:
+    gpu-class: h100-80gb          # Karpenter가 이걸 보고 프로비저닝
+  resourceClaims:
+    - name: gpu
+      resourceClaimTemplateName: gpu-claim  # kube-scheduler가 처리
+```
+
+**동작**: Karpenter가 ResourceClaim을 무시 → nodeSelector로 NodePool 매칭 → 노드 프로비저닝 → DRA Driver 배포 → kube-scheduler가 DRA 매칭 → Pod 배치
+
+:::warning 프로덕션 비권장
+
+| 위험 | 설명 |
+|---|---|
+| **Bin-packing 오류** | Karpenter가 DRA 리소스 소비를 모르므로 GPU 용량 초과 Pod 배치 가능 |
+| **스케일다운 오판** | DRA 리소스 미인식으로 사용 중 노드를 빈 노드로 판단 |
+| **임시 플래그** | 정식 DRA 지원 시 제거 예정 |
+
+PoC/단일 Pod-per-Node 구성에서만 사용하고, **프로덕션은 MNG + Cluster Autoscaler를 권장**합니다.
 :::
 
 ### DRA 하이브리드 아키텍처

--- a/docs/agentic-ai-platform/model-serving/gpu-resource-management.md
+++ b/docs/agentic-ai-platform/model-serving/gpu-resource-management.md
@@ -337,9 +337,59 @@ Kubernetes 1.33과 1.34 버전에서는 GPU 워크로드 관리를 위한 여러
 | **Karpenter** | ❌ 미지원 | `ResourceClaim`이 있는 Pod를 skip ([#1231](https://github.com/kubernetes-sigs/karpenter/issues/1231)) |
 | **EKS Auto Mode** | ❌ 미지원 | 내부 Karpenter 기반으로 동일 제약 |
 
-Karpenter는 Pod의 `spec.resourceClaims`를 감지하면 노드 프로비저닝 자체를 건너뜁니다. 기존 노드에 DRA 드라이버가 설치되어 있어도 **새 노드 스케일아웃이 불가능**합니다.
-
 **참고**: [AWS EKS 공식 문서 — Manage hardware devices](https://docs.aws.amazon.com/eks/latest/userguide/device-management.html)
+:::
+
+#### Karpenter가 DRA를 지원할 수 없는 기술적 이유
+
+단순히 CRD 해석 문제가 아니라, **노드 프로비저닝의 아키텍처적 한계**입니다.
+
+**스케줄링 vs 프로비저닝의 차이:**
+
+| 단계 | 역할 | DRA 지원 |
+|---|---|---|
+| **Pod 스케줄링** (kube-scheduler) | 기존 노드에 Pod 배치 | ✅ 네이티브 지원 |
+| **노드 프로비저닝** (Karpenter) | 새 노드 생성 | ❌ 시뮬레이션 불가 |
+
+Karpenter는 Pod 요구사항을 분석해서 **"아직 존재하지 않는 노드"**에 대해 최적 인스턴스를 계산합니다. DRA에서는 이 계산이 불가능합니다:
+
+1. **ResourceSlice는 노드가 존재해야 생성됨**: DRA Driver가 노드에서 GPU를 탐지한 후 ResourceSlice를 발행하는데, Karpenter는 노드 생성 전에 이 정보가 필요합니다 (닭과 달걀 문제)
+2. **인스턴스→ResourceSlice 매핑 부재**: Device Plugin에서는 `p5.48xlarge → nvidia.com/gpu: 8`을 정적으로 알 수 있지만, DRA에서는 Driver 구현에 따라 ResourceSlice 내용이 달라집니다
+3. **CEL 표현식 시뮬레이션 불가**: DRA는 CEL로 디바이스를 선택하는데, 평가에 필요한 ResourceSlice 속성값이 노드 생성 전에는 존재하지 않습니다
+
+반면 **Cluster Autoscaler는 DRA를 해석하지 않아도 동작**합니다. CA는 "Pending Pod이 있으니 미리 정의된 MNG를 스케일업해"라는 단순한 판단만 하므로, 어떤 인스턴스가 필요한지 시뮬레이션할 필요가 없습니다.
+
+#### Karpenter `IGNORE_DRA_REQUESTS` 워크어라운드
+
+Karpenter에는 `IGNORE_DRA_REQUESTS` 플래그가 있습니다. 이를 활성화하면 Karpenter가 DRA 요구사항을 무시하고, nodeSelector/라벨 등 나머지 조건으로 노드를 프로비저닝합니다.
+
+```yaml
+# Karpenter 설정에서 DRA 무시 활성화
+env:
+  - name: IGNORE_DRA_REQUESTS
+    value: "true"
+```
+
+**동작 흐름:**
+
+```
+Pod (ResourceClaim + nodeSelector: gpu-class=h100)
+  → Karpenter: ResourceClaim 무시, nodeSelector 확인
+    → NodePool 매칭 → p5.48xlarge 프로비저닝
+      → DRA Driver 배포 → ResourceSlice 발행
+        → kube-scheduler: ResourceClaim ↔ ResourceSlice 매칭 → Pod 배치
+```
+
+:::warning IGNORE_DRA_REQUESTS의 제약
+
+이 플래그는 **PoC/테스트 용도**이며 프로덕션에서는 주의가 필요합니다:
+
+- **Bin-packing 오류**: Karpenter가 DRA 리소스 소비를 모르므로 한 노드에 GPU 용량 초과 Pod을 배치할 수 있음
+- **스케일다운 오판**: DRA 리소스를 인식 못해 사용 중인 노드를 빈 노드로 판단할 수 있음
+- **임시 플래그**: 정식 DRA 지원 시 제거 예정
+- **이중 관리**: DRA(ResourceClaim)와 라벨(nodeSelector) 두 곳에서 GPU 의도를 관리해야 하므로 불일치 위험
+
+**프로덕션 권장**: MNG + Cluster Autoscaler
 :::
 
 Kubernetes 초기 단계에서 GPU 리소스 할당은 **Device Plugin** 모델을 사용했습니다. 이 모델은 다음과 같은 근본적인 한계를 가집니다:

--- a/docs/agentic-ai-platform/model-serving/llm-d-eks-automode.md
+++ b/docs/agentic-ai-platform/model-serving/llm-d-eks-automode.md
@@ -632,11 +632,15 @@ spec:
 :::
 
 :::danger llm-d + DRA 사용 시 노드 제약
-llm-d ModelService가 **DRA (ResourceClaim)** 방식으로 GPU를 요청하는 경우, Karpenter와 EKS Auto Mode에서는 노드 프로비저닝이 동작하지 않습니다. Karpenter는 `spec.resourceClaims`가 있는 Pod를 skip합니다.
+llm-d ModelService가 **DRA (ResourceClaim)** 방식으로 GPU를 요청하는 경우, Karpenter와 EKS Auto Mode에서는 노드 프로비저닝이 동작하지 않습니다. Karpenter는 `spec.resourceClaims`가 있는 Pod를 skip합니다 ([PR #2384](https://github.com/kubernetes-sigs/karpenter/pull/2384)).
 
-**DRA를 사용하는 llm-d 배포 시**: 반드시 **Managed Node Group + Cluster Autoscaler**로 GPU 노드를 관리해야 합니다.
+이는 단순 CRD 해석 문제가 아니라 아키텍처적 한계입니다 — DRA의 ResourceSlice는 노드 생성 후 DRA Driver가 발행하므로, Karpenter가 노드 생성 전에 필요한 시뮬레이션이 불가능합니다.
+
+**DRA를 사용하는 llm-d 배포 시**: 반드시 **Managed Node Group + Cluster Autoscaler**로 GPU 노드를 관리해야 합니다. Prefill/Decode 모두 DRA를 사용한다면 둘 다 MNG에서 운영해야 합니다 (Karpenter 혼용 시 KV Cache 전송 토폴로지 불일치 위험).
 
 **DRA 없이 배포하는 경우** (`nvidia.com/gpu` Device Plugin 방식): Auto Mode와 Karpenter에서 정상 동작합니다. 본 문서의 배포 예시는 Device Plugin 방식을 사용합니다.
+
+**PoC 워크어라운드**: Karpenter의 `IGNORE_DRA_REQUESTS` 플래그를 활성화하면 DRA 요구사항을 무시하고 nodeSelector/라벨 기반으로 프로비저닝 가능하나, bin-packing 오류와 스케일다운 오판 위험이 있어 프로덕션에서는 비권장입니다.
 
 상세: [EKS GPU 노드 전략 — DRA 워크로드를 위한 MNG 전략](./eks-gpu-node-strategy.md#56-dra-워크로드를-위한-managed-node-group-전략)
 :::


### PR DESCRIPTION
## Summary

- DRA(Dynamic Resource Allocation)가 Karpenter/EKS Auto Mode와 호환되지 않음을 3개 문서에 명시 (AWS 공식 문서 근거)
- DRA 워크로드는 Managed Node Group 필수 — KEDA + Cluster Autoscaler 기반 스케일아웃 전략 추가
- 현시점 최적 GPU 노드 구성: Karpenter + GPU Operator (Device Plugin + MIG) 권장, DRA 전환 시점 가이드

## 변경 파일

### `gpu-resource-management.md`
- DRA 버전 타임라인 수정 (K8s 1.34 = DRA GA)
- DRA + Karpenter/Auto Mode 비호환 경고 박스 추가
- DRA 흐름도: Karpenter → kube-scheduler + Cluster Autoscaler(MNG) 수정
- DRA 선택 가이드: MNG 필수 조건 명확화
- DRA 워크로드 GPU 스케일아웃 전략 섹션 신규 (2단계: KEDA proactive + CA reactive)

### `eks-gpu-node-strategy.md`
- 노드 타입 비교 테이블에 DRA 호환 행 추가
- 섹션 5.6 "DRA 워크로드를 위한 MNG 전략" 신규 (아키텍처 다이어그램 포함)
- 의사결정 테이블에 DRA, P6e-GB200 행 추가
- 섹션 10.3 "현시점 최적 구성" 전면 개편 — 규모별 권장 구성 + DRA 전환 시점

### `llm-d-eks-automode.md`
- DRA 사용 시 노드 제약 경고 박스 추가
- 마이그레이션 경로 Phase 2 → 2a(Karpenter+MIG) / 2b(MNG+DRA) 분리

## 근거
- [AWS EKS 공식 문서 — Manage hardware devices](https://docs.aws.amazon.com/eks/latest/userguide/device-management.html)
- [Karpenter DRA Issue #1231](https://github.com/kubernetes-sigs/karpenter/issues/1231)
- [AI on EKS — DRA Guide](https://awslabs.github.io/ai-on-eks/docs/guidance/dynamic-resource-allocation)