### PR TITLE
fix(docs): update 7 Cilium / Gateway API reference links returning 404

### DIFF
--- a/docs/benchmarks/cni-performance-comparison.md
+++ b/docs/benchmarks/cni-performance-comparison.md
@@ -3,8 +3,8 @@ title: VPC CNI vs Cilium CNI 성능 비교 벤치마크
 description: EKS 환경에서 VPC CNI와 Cilium CNI의 네트워크 및 애플리케이션 성능을 5개 시나리오(kube-proxy, kube-proxy-less, ENI, 튜닝)로 비교한 벤치마크 보고서
 created: "2026-02-09"
 last_update:
-  date: "2026-06-30"
-  author: YoungJoon Jeong
+  date: "2026-08-29"
+  author: YoungJoon Jeong · SiYeon Hwang
 reading_time: 22
 tags:
   - benchmark
@@ -97,21 +97,21 @@ VPC CNI(kube-proxy)와 Cilium(eBPF)에서 Pod-to-Service 트래픽의 패킷 경
 Cilium Daemon이 커널의 BPF 프로그램을 관리하며, 각 컨테이너와 네트워크 인터페이스(eth0)에 eBPF 프로그램을 주입합니다.
 
 ![Cilium Architecture](/img/benchmarks/cilium-arch.png)
-*출처: [Cilium Component Overview](https://docs.cilium.io/en/stable/overview/component-overview.html)*
+*출처: [Cilium Component Overview](https://docs.cilium.io/en/stable/overview/component-overview/)*
 
 #### Cilium eBPF 패킷 경로
 
 Pod-to-Pod 통신에서 eBPF 프로그램은 veth pair(lxc)에 부착되어 iptables를 완전히 우회합니다. 아래 다이어그램은 Endpoint 간 직접 통신 경로를 보여줍니다.
 
 ![Cilium eBPF Endpoint-to-Endpoint](/img/benchmarks/cilium_bpf_endpoint.svg)
-*출처: [Cilium - Life of a Packet](https://docs.cilium.io/en/stable/network/ebpf/lifeofapacket.html)*
+*출처: [Cilium - Life of a Packet](https://docs.cilium.io/en/stable/network/ebpf/lifeofapacket/)*
 
 #### Cilium Native Routing (ENI 모드)
 
 Native Routing 모드에서 Pod 트래픽은 VXLAN 캡슐화 없이 호스트의 라우팅 테이블을 통해 직접 전달됩니다. ENI 모드에서는 Pod IP가 VPC CIDR에서 직접 할당됩니다.
 
 ![Cilium Native Routing](/img/benchmarks/cilium_native_routing.png)
-*출처: [Cilium Routing](https://docs.cilium.io/en/stable/network/concepts/routing.html)*
+*출처: [Cilium Routing](https://docs.cilium.io/en/stable/network/concepts/routing/)*
 
 #### Cilium ENI IPAM 아키텍처
 

--- a/docs/eks-best-practices/networking-performance/gateway-api-adoption-guide/cilium-eni-gateway-api.md
+++ b/docs/eks-best-practices/networking-performance/gateway-api-adoption-guide/cilium-eni-gateway-api.md
@@ -3,8 +3,8 @@ title: Cilium ENI 모드 + Gateway API 심화 구성
 description: Cilium ENI 모드 아키텍처, Gateway API 리소스 구성, 성능 최적화, Hubble 관측성, BGP Control Plane v2 심화 가이드
 created: "2026-02-14"
 last_update:
-  date: "2026-06-28"
-  author: YoungJoon Jeong
+  date: "2026-08-29"
+  author: YoungJoon Jeong · SiYeon Hwang
 reading_time: 22
 tags:
   - eks
@@ -1816,7 +1816,7 @@ Gateway API Inference Extension이 GA되기 전까지는 **Option 1 (Cilium + Ci
 - **[Gateway API 도입 가이드](/docs/eks-best-practices/networking-performance/gateway-api-adoption-guide)** - 전체 Gateway API 마이그레이션 가이드
 - **[llm-d + EKS 배포 가이드](/docs/agentic-ai-platform/model-serving/inference-frameworks/llm-d-eks-automode)** - llm-d 분산 추론 스택 구성
 - **[Cilium 공식 문서](https://docs.cilium.io/)** - Cilium 프로젝트 공식 문서
-- **[Cilium Gateway API 문서](https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/)** - Cilium의 Gateway API 구현 가이드
+- **[Cilium Gateway API 문서](https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api/)** - Cilium의 Gateway API 구현 가이드
 - **[Gateway API Inference Extension](https://gateway-api.sigs.k8s.io/geps/gep-3567/)** - AI/ML 추론 전용 Gateway API 확장
 - **[AWS EKS Best Practices](https://aws.github.io/aws-eks-best-practices/)** - EKS 모범 사례 가이드
 - **[eBPF 소개](https://ebpf.io/)** - eBPF 기술 개요 및 학습 자료

--- a/docs/eks-best-practices/networking-performance/gateway-api-adoption-guide/index.md
+++ b/docs/eks-best-practices/networking-performance/gateway-api-adoption-guide/index.md
@@ -3,8 +3,8 @@ title: "Gateway API 도입 가이드: NGINX Ingress에서 차세대 트래픽 �
 description: NGINX Ingress Controller EOL 대응, Gateway API 아키텍처, GAMMA Initiative, AWS Native vs 오픈소스 솔루션 비교(AWS LBC·Cilium·NGINX Gateway Fabric·Envoy Gateway·kGateway·Kong), Cilium ENI 통합, 마이그레이션 전략 및 벤치마크 계획
 created: "2026-02-14"
 last_update:
-  date: "2026-06-30"
-  author: devfloor9
+  date: "2026-08-29"
+  author: YoungJoon Jeong · SiYeon Hwang
 reading_time: 30
 tags:
   - eks
@@ -411,7 +411,7 @@ Gateway API는 다음과 같은 계층 구조로 책임을 분리합니다:
 
   ![Gateway API 리소스 모델 — 출처: gateway-api.sigs.k8s.io](https://gateway-api.sigs.k8s.io/images/resource-model.png)
 
-  *출처: [Kubernetes Gateway API 공식 문서](https://gateway-api.sigs.k8s.io/concepts/api-overview/) — GatewayClass → Gateway → xRoute → Service 계층 구조*
+  *출처: [Kubernetes Gateway API 공식 문서](https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/) — GatewayClass → Gateway → xRoute → Service 계층 구조*
 
   <RoleSeparationTable />
 

--- a/docs/eks-best-practices/networking-performance/service-mesh/gamma-initiative.md
+++ b/docs/eks-best-practices/networking-performance/service-mesh/gamma-initiative.md
@@ -3,8 +3,8 @@ title: GAMMA Initiative — 서비스 메시 통합의 미래
 description: GAMMA (Gateway API for Mesh Management and Administration) 소개, East-West 트래픽 관리, 서비스 메시 통합
 created: "2026-02-14"
 last_update:
-  date: "2026-07-15"
-  author: YoungJoon Jeong
+  date: "2026-08-29"
+  author: YoungJoon Jeong · SiYeon Hwang
 reading_time: 2
 tags:
   - gateway-api
@@ -103,8 +103,8 @@ spec:
 ## 참고 자료
 
 ### 공식 문서
-- [GAMMA Initiative](https://gateway-api.sigs.k8s.io/mesh/gamma/) — Gateway API 공식 GAMMA 사양·목표·구성 패턴
-- [Gateway API for Service Mesh](https://gateway-api.sigs.k8s.io/mesh/) — 메시 트래픽에 Gateway API를 적용하는 공식 가이드
+- [GAMMA Initiative](https://gateway-api.sigs.k8s.io/docs/mesh/gamma/) — Gateway API 공식 GAMMA 사양·목표·구성 패턴
+- [Gateway API for Service Mesh](https://gateway-api.sigs.k8s.io/docs/mesh/mesh-overview/) — 메시 트래픽에 Gateway API를 적용하는 공식 가이드
 
 ### 관련 문서 (내부)
 - [서비스 메시 비교 가이드](./index.md) — Istio·Cilium·Linkerd·VPC Lattice 아키텍처·기능·운영 비교


### PR DESCRIPTION
## Background

Cilium and the Kubernetes Gateway API changed their documentation URL structures, and seven reference links now return 404. Response codes were checked directly on 2026-08-29.

The same was confirmed against the published site: the four pages below were downloaded and compared, and the 404 links are still exposed on them.

## Changes

| File | Line | Before (404) | After (200) |
|------|------|--------------|-------------|
| `benchmarks/cni-performance-comparison.md` | 100 | `docs.cilium.io/en/stable/overview/component-overview.html` | `…/overview/component-overview/` |
| 〃 | 107 | `…/network/ebpf/lifeofapacket.html` | `…/network/ebpf/lifeofapacket/` |
| 〃 | 114 | `…/network/concepts/routing.html` | `…/network/concepts/routing/` |
| `gateway-api-adoption-guide/cilium-eni-gateway-api.md` | 1819 | `…/network/servicemesh/gateway-api/` | `…/network/servicemesh/gateway-api/gateway-api/` |
| `gateway-api-adoption-guide/index.md` | 414 | `gateway-api.sigs.k8s.io/concepts/api-overview/` | `…/docs/concepts/api-overview/` |
| `service-mesh/gamma-initiative.md` | 106 | `gateway-api.sigs.k8s.io/mesh/gamma/` | `…/docs/mesh/gamma/` |
| 〃 | 107 | `gateway-api.sigs.k8s.io/mesh/` | `…/docs/mesh/mesh-overview/` |

The `last_update` block (date and author) was also refreshed in all four changed files.

### Cilium — from `.html` extensions to trailing slashes

The Cilium docs dropped extension-based URLs in favour of directory-style ones. The paths themselves are unchanged, so only the extension needs replacing.

### Gateway API — the whole doc tree moved under `/docs/`

`gateway-api.sigs.k8s.io/sitemap.xml` shows the entire documentation tree relocated beneath a `/docs/` prefix.

```
/docs/mesh/gamma/
/docs/mesh/mesh-overview/
/docs/concepts/api-overview/
```

`/mesh/`, `/mesh/gamma/`, and `/concepts/api-overview/` return 404 with no redirect.

`/concepts/gamma/` does resolve to 200, but only via a 301 through `/docs/mesh/` to `/docs/mesh/mesh-overview/` — **it is an intermediate URL, and it collapses the two links into one page.** To preserve the distinction the source made between the "GAMMA specification" and the "mesh adoption guide", the two canonical paths are targeted directly.

| Entry | Target page |
|-------|-------------|
| GAMMA Initiative | `/docs/mesh/gamma/` — GAMMA specification, goals, configuration patterns |
| Gateway API for Service Mesh | `/docs/mesh/mesh-overview/` — guide for applying Gateway API to mesh traffic |

### Existing precedent in the repository

For the Cilium Gateway API link in `cilium-eni-gateway-api.md`, `index.md` in the same document set already uses the correct form.

```
docs/…/gateway-api-adoption-guide/index.md:947
  - [Cilium Gateway API 문서](https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api/)
```

I matched that form.

## Site impact

All of these are external links in a `## References` section or a figure-source caption. No prose and no build output structure changes.

| Published page | Affected links |
|------|-----------|
| [`/docs/benchmarks/cni-performance-comparison`](https://devfloor9.github.io/engineering-playbook/docs/benchmarks/cni-performance-comparison) | 3 figure sources (Component Overview · Life of a Packet · Routing) |
| [`/docs/…/gateway-api-adoption-guide`](https://devfloor9.github.io/engineering-playbook/docs/eks-best-practices/networking-performance/gateway-api-adoption-guide) | 1 resource-model figure source |
| [`/docs/…/gateway-api-adoption-guide/cilium-eni-gateway-api`](https://devfloor9.github.io/engineering-playbook/docs/eks-best-practices/networking-performance/gateway-api-adoption-guide/cilium-eni-gateway-api) | 1 reference |
| [`/docs/…/service-mesh/gamma-initiative`](https://devfloor9.github.io/engineering-playbook/docs/eks-best-practices/networking-performance/service-mesh/gamma-initiative) | 2 references |

The corresponding English pages (`/en/docs/…`) carry the same 404 links. They are left untouched per the i18n policy.

## Verification

- The 7 replacement URLs checked with `curl -s -o /dev/null -w '%{http_code}'` — **all 200 without following redirects** (2026-08-29)
- The 7 original URLs all return 404 under the same conditions
- The other 7 Cilium / Gateway API links on the same pages (`/bpf/`, `/network/clustermesh/`, `geps/gep-3567/`, …) were also checked — all 200, so left unchanged
- The four published pages were downloaded and compared for the old URLs
- Confirmed no occurrences of the old URLs remain anywhere in the repository
- `npm run build` exits 0
