### PR TITLE
fix(docs): health-check-mismatch.md에서 누락된 networking.md 링크 수정

### DIFF
--- a/docs/eks-best-practices/operations-reliability/eks-debugging/health-check-mismatch.md
+++ b/docs/eks-best-practices/operations-reliability/eks-debugging/health-check-mismatch.md
@@ -33,7 +33,7 @@ Kubernetes Probe와 Load Balancer/Ingress Controller의 Health Check는 **독립
 
 :::tip 관련 문서 참조
 - **Probe 기초**: [Pod 헬스체크 & 라이프사이클](../eks-pod-health-lifecycle.md) — Probe 설정 상세
-- **네트워킹 디버깅**: [네트워킹 문제 해결](#) — Service/DNS 이슈 (추후 작성 예정)
+- **네트워킹 디버깅**: [네트워킹 문제 해결](./networking.md) — Service/DNS 이슈
 - **고가용성**: [EKS 고가용성 아키텍처 가이드](../eks-resiliency-guide.md) — PDB, Graceful Shutdown
 :::
 
@@ -857,4 +857,4 @@ aws ec2 describe-security-groups --group-ids sg-xxxxxxxx
 
 ---
 
-**다음 단계**: [네트워킹 문제 해결](#) (추후 작성 예정) — Service Discovery, DNS, CNI 디버깅
+**다음 단계**: [네트워킹 문제 해결](./networking.md) — Service Discovery, DNS, CNI 디버깅

--- a/i18n/en/docusaurus-plugin-content-docs/current/eks-best-practices/operations-reliability/eks-debugging/health-check-mismatch.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/eks-best-practices/operations-reliability/eks-debugging/health-check-mismatch.md
@@ -32,7 +32,7 @@ This document clarifies the mechanism differences between K8s Probes and ALB/NLB
 
 :::tip Related Documents
 - **Probe basics**: [Pod Health & Lifecycle](../eks-pod-health-lifecycle.md) — Detailed Probe configuration
-- **Networking debugging**: [Networking Troubleshooting](#) — Service/DNS issues (coming soon)
+- **Networking debugging**: [Networking Troubleshooting](./networking.md) — Service/DNS issues
 - **High availability**: [EKS Resiliency Guide](../eks-resiliency-guide.md) — PDB, Graceful Shutdown
 :::
 
@@ -856,4 +856,4 @@ Diagnosis order during an outage:
 
 ---
 
-**Next**: [Networking Troubleshooting](#) (coming soon) — Service Discovery, DNS, CNI debugging
+**Next**: [Networking Troubleshooting](./networking.md) — Service Discovery, DNS, CNI debugging


### PR DESCRIPTION
## 배경

`eks-debugging/networking.md`를 참조하는 문서 중 `health-check-mismatch.md`에만 빈 링크 `](#)`와 "추후 작성 예정" 안내가 남아 있습니다. 형제 문서 6종은 이미 `./networking.md`로 링크하고 있습니다.

## 변경 사항

KO·EN 각 2곳, 총 4줄입니다. 바뀐 위치는 상단 `:::tip 관련 문서 참조` 블록과 하단 "다음 단계" 줄입니다.

- `](#)` → `](./networking.md)`
- `(추후 작성 예정)` / `(coming soon)` 제거 — 사실과 다름

링크 텍스트와 frontmatter는 그대로입니다.

## 검증

**AS-IS** — 현재 배포된 사이트, 문서 하단 "다음 단계" 링크. URL에 `#`만 붙습니다.
<img width="1080" height="743" alt="health-check-link-as-is" src="https://github.com/user-attachments/assets/ab5aef7e-1144-4a5a-ae96-41c35c497f1e" />


**TO-BE** — 이 PR을 적용한 로컬 빌드, 같은 링크.
<img width="1080" height="743" alt="health-check-link-to-be" src="https://github.com/user-attachments/assets/1305ebe0-7271-47ed-95dc-40579e3bd2ad" />

